### PR TITLE
[FEATURE#11827] Appels curl pour confer RMQ

### DIFF
--- a/src/ETNA/FeatureContext/RabbitMQ.php
+++ b/src/ETNA/FeatureContext/RabbitMQ.php
@@ -2,6 +2,8 @@
 
 namespace ETNA\FeatureContext;
 
+// TODO Utiliser un provider Guzzle pour remplacer les curl
+
 trait RabbitMQ {
     /**
      * @BeforeSuite
@@ -9,8 +11,9 @@ trait RabbitMQ {
     static public function createVhosts()
     {
         foreach (self::$vhosts as $vhost) {
-            passthru("rabbitmqctl add_vhost {$vhost} > /dev/null");
-            passthru("rabbitmqctl set_permissions -p {$vhost} guest '.*' '.*' '.*' > /dev/null");
+            $vhost = str_replace('/', '%2f', $vhost);
+            passthru("curl -i -s -u guest:guest -H \"content-type:application/json\" -o /dev/null -XPUT http://127.0.0.1:15672/api/vhosts/{$vhost}");
+            passthru("curl -i -s -u guest:guest -H \"content-type:application/json\" -o /dev/null -XPUT http://127.0.0.1:15672/api/permissions/{$vhost}/guest -d '{ \"configure\":\".*\", \"write\":\".*\", \"read\":\".*\" }'");
         }
     }
 
@@ -20,7 +23,8 @@ trait RabbitMQ {
     static public function deleteVhosts()
     {
         foreach (self::$vhosts as $vhost) {
-            passthru("rabbitmqctl delete_vhost {$vhost} > /dev/null");
+            $vhost = str_replace('/', '%2f', $vhost);
+            passthru("curl -i -s -u guest:guest -H \"content-type:application/json\" -o /dev/null -XDELETE http://127.0.0.1:15672/api/vhosts/{$vhost}");
         }
     }
 }


### PR DESCRIPTION
On utilise maintenant curl et l'api http de rmq en lieu et place de
rabbitmqctl Cela permet de configurer rmq pour les tests, sans que la machine
qui les exécutent ne possède rabbitmqctl
