### PR TITLE
[FEATURE#21027] Mise a jour de guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "gquemener/behat-analysis-extension": "~1.0",
         "phpunit/php-code-coverage": "~2.0",
         "phpunit/phpcov": "~2.0",
-        "guzzlehttp/guzzle": "~5.0",
+        "guzzlehttp/guzzle": "~6.1",
         "etna/php-rsa": "~0.2.0"
     },
     "autoload": {


### PR DESCRIPTION
- Mise à jour de guzzle/http

Pour le filemanager provider, j'utilise la version 6.1 de guzzle, mais dans le `composer-behat-utils`, on utilise la 5.x, donc pour faire mes tests, je dois mettre à jour ce dernier.