### PR TITLE
[FIX#28659] Ajout de l'env dans RmqContext

### DIFF
--- a/src/RabbitContext.php
+++ b/src/RabbitContext.php
@@ -8,6 +8,16 @@ class RabbitContext extends BaseContext
 {
     public static $vhosts = ["/test-behat"];
 
+    /**
+     * @BeforeSuite
+     */
+    public static function loadEnv()
+    {
+        if (file_exists('./app/env/' . getenv('APPLICATION_ENV') . '.php')) {
+            require_once './app/env/' . getenv('APPLICATION_ENV') . '.php';
+        }
+    }
+
     private static function getRabbitMqClient()
     {
         $rmq_url  = getenv("RABBITMQ_URL");


### PR DESCRIPTION
- Ajout d'une fonction qui require le fichier d'env s'il existe